### PR TITLE
targetSdkVersion mismatch

### DIFF
--- a/Application/build.gradle
+++ b/Application/build.gradle
@@ -36,7 +36,7 @@ android {
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion "android-O"
+        targetSdkVersion "O"
     }
 
     compileOptions {


### PR DESCRIPTION
Hi,

Thanks for providing good sample app!

When installing with $ adb install -t Application-debug.apk" on Pixel (OPR1.170321.003),
Err "Requires development platform android-O (current platform is any of [O])]" occurred.

I've tried "O" for targetSdkVersion and solved the problem.

Could you please check?

(PS; icon for app is missing and build is failed...)