### PR TITLE
Fix links to API documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ to send. You can also create notification channels to reflect choices made by us
 your app. For example, you might setup separate notification channels for each
 conversation group created by a user in a messaging app.
 
-To create a channel, call `[NotificationManager.createNotificationChannels()][1]`. You
-can then use `[Notification.Builder.setChannel()][2]` to assign your notification to that
+To create a channel, call [`NotificationManager.createNotificationChannels()`][1]. You
+can then use [`Notification.Builder.setChannel()`][2] to assign your notification to that
 channel.
 
 Users can now manage most of the settings associated with notifications using a
@@ -36,7 +36,7 @@ startActivity(intent);
 
 
 [1]: https://developer.android.com/reference/android/app/NotificationManager.html#createNotificationChannels(java.util.List<android.app.NotificationChannel>)
-[2]: https://android-dot-devsite.googleplex.com/reference/android/app/Notification.Builder.html#setChannel(java.lang.String)
+[2]: https://developer.android.com/reference/android/app/Notification.Builder.html#setChannel(java.lang.String)
 
 Pre-requisites
 --------------


### PR DESCRIPTION
This fixes the Markdown so the links are actually clickable. The second URL pointed to an internal Google site and was replaced with a link to the public API documentation.